### PR TITLE
Performance improvements to get_monthly_user_activity()

### DIFF
--- a/classes/report_graphic.php
+++ b/classes/report_graphic.php
@@ -185,6 +185,10 @@ class report_graphic extends Gcharts {
             $montharr[$monthabbrev][0] = $monthabbrev;
         }
         $sql .= "FROM {user} u
+                WHERE u.id IN (SELECT ra.userid  
+                                FROM mdl_role_assignments AS ra
+			                    JOIN mdl_context AS context ON ra.contextid = context.id AND context.contextlevel = 50
+			                    WHERE ra.roleid = 5 AND context.instanceid = $courseid)
                 ORDER BY u.id";
         $result = $DB->get_records_sql($sql);
 


### PR DESCRIPTION
We have a 33K users Moodle install. and for us to be able to run this (beautiful) report on a per course basis, without timeout errors, we needed to narrow the graphs population to the users of that specific course. (It's seems also the right thing to do, regardless performance)
So I am adding the suggested patch to include only the users of the specific course being viewed.
Please review and see if you can integrate.
Kindly, 
Nadav
